### PR TITLE
cleanup: Remove 'status_bar_' config prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ All of the configuration options can be changed at runtime as well.
 
 Example configuration:
 ```
-spacebar -m config status_bar_text_font         "Helvetica Neue:Bold:12.0"
-spacebar -m config status_bar_icon_font         "Font Awesome 5:Regular:12.0"
-spacebar -m config status_bar_background_color  0xff202020
-spacebar -m config status_bar_foreground_color  0xffa8a8a8
-spacebar -m config status_bar_space_icon_strip  I II III IV V VI VII VIII IX X
-spacebar -m config status_bar_power_icon_strip   
-spacebar -m config status_bar_space_icon        
-spacebar -m config status_bar_clock_icon        
+spacebar -m config text_font         "Helvetica Neue:Bold:12.0"
+spacebar -m config icon_font         "Font Awesome 5:Regular:12.0"
+spacebar -m config background_color  0xff202020
+spacebar -m config foreground_color  0xffa8a8a8
+spacebar -m config space_icon_strip  I II III IV V VI VII VIII IX X
+spacebar -m config power_icon_strip   
+spacebar -m config space_icon        
+spacebar -m config clock_icon        
 ```
 
 - Sample configuration files can be found in the [&nearr;&nbsp;examples][spacebar-examples] directory. Refer to the [&nearr;&nbsp;documentation][spacebar-docs].

--- a/doc/spacebar.1
+++ b/doc/spacebar.1
@@ -115,6 +115,11 @@ Specify a general symbol to use for any given space that does not have a match i
 .RS 4
 Specify a symbol to represent the current time.
 .RE
+.sp
+\fBclock_format\fP [\fI<sym>\fP]
+.RS 4
+Specify a format for the current time, according to the strftime function.
+.RE
 .SH "EXIT CODES"
 .sp
 If \fBspacebar\fP can\(cqt handle a message, it will return a non\-zero exit code.

--- a/doc/spacebar.1
+++ b/doc/spacebar.1
@@ -70,48 +70,48 @@ Get or set the value of <setting>.
 Enable output of debug information to stdout.
 .RE
 .sp
-\fBstatus_bar_text_font\fP [\fI<font_family>:<font_style>:<font_size>\fP]
+\fBtext_font\fP [\fI<font_family>:<font_style>:<font_size>\fP]
 .RS 4
 Specify name, style and size of font to use for drawing text.
 .br
 Use \fIFont Book.app\fP to identify the correct name.
 .RE
 .sp
-\fBstatus_bar_icon_font\fP [\fI<font_family>:<font_style>:<font_size>\fP]
+\fBicon_font\fP [\fI<font_family>:<font_style>:<font_size>\fP]
 .RS 4
 Specify name, style and size of font to use for drawing icon symbols.
 .br
 Use \fIFont Book.app\fP to identify the correct name.
 .RE
 .sp
-\fBstatus_bar_background_color\fP [\fI<COLOR>\fP]
+\fBbackground_color\fP [\fI<COLOR>\fP]
 .RS 4
 Color to use for drawing status bar background.
 .RE
 .sp
-\fBstatus_bar_foreground_color\fP [\fI<COLOR>\fP]
+\fBforeground_color\fP [\fI<COLOR>\fP]
 .RS 4
 Color to use for drawing status bar elements.
 .RE
 .sp
-\fBstatus_bar_space_icon_strip\fP [\fI<sym_1> <sym_2> <sym_n>\fP]
+\fBspace_icon_strip\fP [\fI<sym_1> <sym_2> <sym_n>\fP]
 .RS 4
 Specify symbols separated by whitespace to be used for visualizing spaces.
 .RE
 .sp
-\fBstatus_bar_power_icon_strip\fP [\fI<sym_battery> <sym_ac>\fP]
+\fBpower_icon_strip\fP [\fI<sym_battery> <sym_ac>\fP]
 .RS 4
 Specify two symbols separated by whitespace.
 .br
 The first symbol represents battery power and the second symbol indicates AC.
 .RE
 .sp
-\fBstatus_bar_space_icon\fP [\fI<sym>\fP]
+\fBspace_icon\fP [\fI<sym>\fP]
 .RS 4
-Specify a general symbol to use for any given space that does not have a match in \fIstatus_bar_space_icon_strip\fP.
+Specify a general symbol to use for any given space that does not have a match in \fIspace_icon_strip\fP.
 .RE
 .sp
-\fBstatus_bar_clock_icon\fP [\fI<sym>\fP]
+\fBclock_icon\fP [\fI<sym>\fP]
 .RS 4
 Specify a symbol to represent the current time.
 .RE

--- a/doc/spacebar.asciidoc
+++ b/doc/spacebar.asciidoc
@@ -60,34 +60,34 @@ Settings
 *debug_output* ['<BOOL_SEL>']::
     Enable output of debug information to stdout.
 
-*status_bar_text_font* ['<font_family>:<font_style>:<font_size>']::
+*text_font* ['<font_family>:<font_style>:<font_size>']::
     Specify name, style and size of font to use for drawing text. +
     Use 'Font Book.app' to identify the correct name.
 
-*status_bar_icon_font* ['<font_family>:<font_style>:<font_size>']::
+*icon_font* ['<font_family>:<font_style>:<font_size>']::
     Specify name, style and size of font to use for drawing icon symbols. +
     Use 'Font Book.app' to identify the correct name.
 
-*status_bar_background_color* ['<COLOR>']::
+*background_color* ['<COLOR>']::
     Color to use for drawing status bar background.
 
-*status_bar_foreground_color* ['<COLOR>']::
+*foreground_color* ['<COLOR>']::
     Color to use for drawing status bar elements.
 
-*status_bar_space_icon_strip* ['<sym_1> <sym_2> <sym_n>']::
+*space_icon_strip* ['<sym_1> <sym_2> <sym_n>']::
     Specify symbols separated by whitespace to be used for visualizing spaces.
 
-*status_bar_power_icon_strip* ['<sym_battery> <sym_ac>']::
+*power_icon_strip* ['<sym_battery> <sym_ac>']::
     Specify two symbols separated by whitespace. +
     The first symbol represents battery power and the second symbol indicates AC.
 
-*status_bar_space_icon* ['<sym>']::
-    Specify a general symbol to use for any given space that does not have a match in 'status_bar_space_icon_strip'.
+*space_icon* ['<sym>']::
+    Specify a general symbol to use for any given space that does not have a match in 'space_icon_strip'.
 
-*status_bar_clock_icon* ['<sym>']::
+*clock_icon* ['<sym>']::
     Specify a symbol to represent the current time.
 
-*status_bar_clock_format* ['<sym>']::
+*clock_format* ['<sym>']::
     Specify a format for the current time, according to the strftime function.
 
 Exit Codes

--- a/examples/spacebarrc
+++ b/examples/spacebarrc
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
-spacebar -m config status_bar_text_font         "Helvetica Neue:Bold:12.0"
-spacebar -m config status_bar_icon_font         "Font Awesome 5 Free:Regular:12.0"
-spacebar -m config status_bar_background_color  0xff202020
-spacebar -m config status_bar_foreground_color  0xffa8a8a8
-spacebar -m config status_bar_space_icon_strip  I II III IV V VI VII VIII IX X
-spacebar -m config status_bar_power_icon_strip   
-spacebar -m config status_bar_space_icon        
-spacebar -m config status_bar_clock_icon        
-spacebar -m config status_bar_clock_format      "%d/%m/%y %R"
+spacebar -m config text_font         "Helvetica Neue:Bold:12.0"
+spacebar -m config icon_font         "Font Awesome 5 Free:Regular:12.0"
+spacebar -m config background_color  0xff202020
+spacebar -m config foreground_color  0xffa8a8a8
+spacebar -m config space_icon_strip  I II III IV V VI VII VIII IX X
+spacebar -m config power_icon_strip   
+spacebar -m config space_icon        
+spacebar -m config clock_icon        
+spacebar -m config clock_format      "%d/%m/%y %R"
 
 echo "spacebar configuration loaded.."

--- a/src/message.c
+++ b/src/message.c
@@ -12,15 +12,15 @@ extern bool g_verbose;
 
 /* --------------------------------DOMAIN CONFIG-------------------------------- */
 #define COMMAND_CONFIG_DEBUG_OUTPUT          "debug_output"
-#define COMMAND_CONFIG_BAR_TEXT_FONT         "status_bar_text_font"
-#define COMMAND_CONFIG_BAR_ICON_FONT         "status_bar_icon_font"
-#define COMMAND_CONFIG_BAR_BACKGROUND        "status_bar_background_color"
-#define COMMAND_CONFIG_BAR_FOREGROUND        "status_bar_foreground_color"
-#define COMMAND_CONFIG_BAR_SPACE_STRIP       "status_bar_space_icon_strip"
-#define COMMAND_CONFIG_BAR_POWER_STRIP       "status_bar_power_icon_strip"
-#define COMMAND_CONFIG_BAR_SPACE_ICON        "status_bar_space_icon"
-#define COMMAND_CONFIG_BAR_CLOCK_ICON        "status_bar_clock_icon"
-#define COMMAND_CONFIG_BAR_CLOCK_FORMAT      "status_bar_clock_format"
+#define COMMAND_CONFIG_BAR_TEXT_FONT         "text_font"
+#define COMMAND_CONFIG_BAR_ICON_FONT         "icon_font"
+#define COMMAND_CONFIG_BAR_BACKGROUND        "background_color"
+#define COMMAND_CONFIG_BAR_FOREGROUND        "foreground_color"
+#define COMMAND_CONFIG_BAR_SPACE_STRIP       "space_icon_strip"
+#define COMMAND_CONFIG_BAR_POWER_STRIP       "power_icon_strip"
+#define COMMAND_CONFIG_BAR_SPACE_ICON        "space_icon"
+#define COMMAND_CONFIG_BAR_CLOCK_ICON        "clock_icon"
+#define COMMAND_CONFIG_BAR_CLOCK_FORMAT      "clock_format"
 
 /* --------------------------------COMMON ARGUMENTS----------------------------- */
 #define ARGUMENT_COMMON_VAL_ON     "on"


### PR DESCRIPTION
Hey @somdoron 👋 Thanks for `statusbar`! I'd been looking to do the same thing, so I was delighted when someone pointed me to your repo.

I figured as this project is now simply a status bar on its own, the
`status_bar_` prefix on all config options seemed superfluous :)

So, hopefully this simple cleanup is a welcomed change