### PR TITLE
Fix bar flicker when mouse moves between monitors

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -154,7 +154,7 @@ static EVENT_CALLBACK(EVENT_HANDLER_DISPLAY_CHANGED)
 
     debug("%s: %d\n", __FUNCTION__, g_display_manager.current_display_id);
 
-    bar_manager_display_changed(&g_bar_manager);
+    bar_manager_refresh(&g_bar_manager);
 
     return EVENT_SUCCESS;
 }


### PR DESCRIPTION
When the cursor moves between displays the spacebar is destroyed and redrawn, causing a noticeable flicker. 

I fixed this in the `DISPLAY_CHANGED` event handler to call `bar_manager_refresh` which just updates the content of the existing spacebar, rather than calling `bar_manager_display_changed` which redraws everything.