### PR TITLE
[Request for consideration/discussion] enhancement: Nicer current space indicator

### DIFF
--- a/examples/spacebarrc
+++ b/examples/spacebarrc
@@ -4,6 +4,7 @@ spacebar -m config text_font         "Helvetica Neue:Bold:12.0"
 spacebar -m config icon_font         "Font Awesome 5 Free:Regular:12.0"
 spacebar -m config background_color  0xff202020
 spacebar -m config foreground_color  0xffa8a8a8
+spacebar -m config space_icon_color  0xff458588
 spacebar -m config space_icon_strip  I II III IV V VI VII VIII IX X
 spacebar -m config power_icon_strip   
 spacebar -m config space_icon        

--- a/src/bar.c
+++ b/src/bar.c
@@ -236,24 +236,18 @@ void bar_refresh(struct bar *bar)
             int index = mission_control_index(space_list[i]) - 1;
 
             struct bar_line space_line = index >= buf_len(g_bar_manager.space_icon_strip)
-                                       ? g_bar_manager.space_icon
-                                       : g_bar_manager.space_icon_strip[index];
+              ? g_bar_manager.space_icon
+              : g_bar_manager.space_icon_strip[index];
             if (i == 0) {
-                pos = bar_align_line(bar, space_line, ALIGN_LEFT, ALIGN_CENTER);
+              pos = bar_align_line(bar, space_line, ALIGN_LEFT, ALIGN_CENTER);
             } else {
-                pos.x += 25;
+              pos.x += 25;
             }
-
-            bar_draw_line(bar, space_line, pos.x, pos.y);
 
             if (sid == space_list[i]) {
-                CGPoint new_pos = CGContextGetTextPosition(bar->context);
-                struct bar_line mark_line = g_bar_manager.space_underline;
-                CGPoint mark_pos = bar_align_line(bar, mark_line, 0, ALIGN_BOTTOM);
-                mark_pos.x = mark_pos.x - mark_line.bounds.size.width / 2 - space_line.bounds.size.width / 2;
-                bar_draw_line(bar, mark_line, mark_pos.x, mark_pos.y);
-                CGContextSetTextPosition(bar->context, new_pos.x, new_pos.y);
+              space_line.color = g_bar_manager.space_icon_color;
             }
+            bar_draw_line(bar, space_line, pos.x, pos.y);
 
             final_bar_left_x = pos.x + space_line.bounds.size.width + 10;
         }

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -16,6 +16,12 @@ void bar_manager_set_background_color(struct bar_manager *bar_manager, uint32_t 
     bar_manager_refresh(bar_manager);
 }
 
+void bar_manager_set_space_icon_color(struct bar_manager *bar_manager, uint32_t color)
+{
+  bar_manager->space_icon_color = rgba_color_from_hex(color);
+  bar_manager_refresh(bar_manager);
+}
+
 void bar_manager_set_text_font(struct bar_manager *bar_manager, char *font_string)
 {
     if (bar_manager->t_font) {
@@ -215,6 +221,7 @@ void bar_manager_init(struct bar_manager *bar_manager)
     bar_manager_set_icon_font(bar_manager, string_copy("Font Awesome 5 Free:Regular:10.0"));
     bar_manager_set_background_color(bar_manager, 0xff202020);
     bar_manager_set_foreground_color(bar_manager, 0xffa8a8a8);
+    bar_manager_set_space_icon_color(bar_manager, 0xffd75f5f);
     bar_manager_set_clock_icon(bar_manager, string_copy(" "));
     bar_manager_set_clock_format(bar_manager, string_copy("%R"));
     bar_manager_set_space_icon(bar_manager, string_copy("*"));

--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -16,6 +16,7 @@ struct bar_manager
     char *_space_icon;
     struct rgba_color foreground_color;
     struct rgba_color background_color;
+    struct rgba_color space_icon_color;
     struct rgba_color background_color_dim;
     struct bar_line *space_icon_strip;
     struct bar_line space_icon;
@@ -29,6 +30,7 @@ struct bar_manager
 
 void bar_manager_set_foreground_color(struct bar_manager *bar_manager, uint32_t color);
 void bar_manager_set_background_color(struct bar_manager *bar_manager, uint32_t color);
+void bar_manager_set_space_icon_color(struct bar_manager *bar_manager, uint32_t color);
 void bar_manager_set_text_font(struct bar_manager *bar_manager, char *font_string);
 void bar_manager_set_icon_font(struct bar_manager *bar_manager, char *font_string);
 void bar_manager_set_space_strip(struct bar_manager *bar_manager, char **icon_strip);

--- a/src/message.c
+++ b/src/message.c
@@ -14,6 +14,7 @@ extern bool g_verbose;
 #define COMMAND_CONFIG_DEBUG_OUTPUT          "debug_output"
 #define COMMAND_CONFIG_BAR_TEXT_FONT         "text_font"
 #define COMMAND_CONFIG_BAR_ICON_FONT         "icon_font"
+#define COMMAND_CONFIG_BAR_SPACE_ICON_COLOR  "space_icon_color"
 #define COMMAND_CONFIG_BAR_BACKGROUND        "background_color"
 #define COMMAND_CONFIG_BAR_FOREGROUND        "foreground_color"
 #define COMMAND_CONFIG_BAR_SPACE_STRIP       "space_icon_strip"
@@ -194,6 +195,18 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
             fprintf(rsp, "%s\n", g_bar_manager._clock_icon ? g_bar_manager._clock_icon : "");
         } else {
             bar_manager_set_clock_format(&g_bar_manager, token_to_string(token));
+        }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_SPACE_ICON_COLOR)) {
+        struct token value = get_token(&message);
+        if (!token_is_valid(value)) {
+            fprintf(rsp, "0x%x\n", g_bar_manager.space_icon_color.p);
+        } else {
+            uint32_t color = token_to_uint32t(value);
+            if (color) {
+                bar_manager_set_space_icon_color(&g_bar_manager, color);
+            } else {
+                daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+            }
         }
     }
     else {


### PR DESCRIPTION
![demo](https://i.imgur.com/KulEDax.gif)


These changes introduce two things:
- Switch from an underline indicator for the current space to simply
colouring the icon
- Provide a `space_icon_color` config option to set the colour of the
current space icon

Figured I'd submit these for consideration :) Quite opinionated, so I'm open to discussion on whether we might want to provide an option to configure either the current underline, or the coloured icon as the current space indicator. I personally find the underline indicator to be too hard to notice.