### PR TITLE
feature: DND indicator

### DIFF
--- a/doc/spacebar.asciidoc
+++ b/doc/spacebar.asciidoc
@@ -90,6 +90,9 @@ Settings
 *clock_format* ['<sym>']::
     Specify a format for the current time, according to the strftime function.
 
+*dnd_icon* ['<sym>']::
+    Specify a symbol to represent the current DoNotDisturb status.
+
 Exit Codes
 ----------
 

--- a/examples/spacebarrc
+++ b/examples/spacebarrc
@@ -9,6 +9,7 @@ spacebar -m config space_icon_strip  I II III IV V VI VII VIII IX X
 spacebar -m config power_icon_strip   
 spacebar -m config space_icon        
 spacebar -m config clock_icon        
+spacebar -m config dnd_icon          
 spacebar -m config clock_format      "%d/%m/%y %R"
 
 echo "spacebar configuration loaded.."

--- a/src/bar.c
+++ b/src/bar.c
@@ -282,6 +282,7 @@ void bar_refresh(struct bar *bar)
     bool has_batt = false;
     bool charging = false;
     int percent = bar_find_battery_life(&has_batt, &charging);
+    int batt_line_pos;
     if (has_batt) {
       char batt[255];
       snprintf(batt, sizeof(batt), "%' '3d%%", percent);
@@ -293,10 +294,22 @@ void bar_refresh(struct bar *bar)
       struct bar_line batt_icon = charging ? g_bar_manager.power_icon : g_bar_manager.battr_icon;
       CGPoint pi_pos = bar_align_line(bar, batt_icon, 0, ALIGN_CENTER);
       pi_pos.x = p_pos.x - batt_icon.bounds.size.width;
+      batt_line_pos = pi_pos.x;
 
       bar_draw_line(bar, batt_icon, pi_pos.x, pi_pos.y);
       bar_destroy_line(batt_line);
     }
+
+    NSUserDefaults* defaults = [[NSUserDefaults alloc]initWithSuiteName:@"com.apple.notificationcenterui"];
+    bool dnd = [defaults boolForKey:@"doNotDisturb"];
+    if (dnd) {
+      struct bar_line dnd_icon = g_bar_manager.dnd_icon;
+      CGPoint di_pos = bar_align_line(bar, dnd_icon, 0, ALIGN_CENTER);
+      di_pos.x = batt_line_pos - dnd_icon.bounds.size.width - 15;
+
+      bar_draw_line(bar, dnd_icon, di_pos.x, di_pos.y);
+    }
+
 
     // BAR CENTER
     char *title = focused_window_title();

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -6,6 +6,7 @@ void bar_manager_set_foreground_color(struct bar_manager *bar_manager, uint32_t 
     if (bar_manager->_space_icon_strip) bar_manager_set_space_strip(bar_manager, bar_manager->_space_icon_strip);
     if (bar_manager->_power_icon_strip) bar_manager_set_power_strip(bar_manager, bar_manager->_power_icon_strip);
     if (bar_manager->_clock_icon) bar_manager_set_clock_icon(bar_manager, bar_manager->_clock_icon);
+    if (bar_manager->_dnd_icon) bar_manager_set_dnd_icon(bar_manager, bar_manager->_dnd_icon);
     if (bar_manager->_space_icon) bar_manager_set_space_icon(bar_manager, bar_manager->_space_icon);
     bar_manager_refresh(bar_manager);
 }
@@ -59,6 +60,7 @@ void bar_manager_set_icon_font(struct bar_manager *bar_manager, char *font_strin
   if (bar_manager->_power_icon_strip) bar_manager_set_power_strip(bar_manager, bar_manager->_power_icon_strip);
     if (bar_manager->_clock_icon) bar_manager_set_clock_icon(bar_manager, bar_manager->_clock_icon);
     if (bar_manager->_space_icon) bar_manager_set_space_icon(bar_manager, bar_manager->_space_icon);
+    if (bar_manager->_dnd_icon) bar_manager_set_dnd_icon(bar_manager, bar_manager->_dnd_icon);
     bar_manager_refresh(bar_manager);
 }
 
@@ -143,6 +145,7 @@ void bar_manager_set_clock_format(struct bar_manager *bar_manager, char *format)
     bar_manager_set_text_font(bar_manager, bar_manager->t_font_prop);
 }
 
+
 void bar_manager_set_space_icon(struct bar_manager *bar_manager, char *icon)
 {
     if (bar_manager->space_icon.line) {
@@ -160,6 +163,25 @@ void bar_manager_set_space_icon(struct bar_manager *bar_manager, char *icon)
     bar_manager->space_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_space_icon, bar_manager->foreground_color);
 
     bar_manager_refresh(bar_manager);
+}
+
+void bar_manager_set_dnd_icon(struct bar_manager *bar_manager, char *icon)
+{
+  if (bar_manager->dnd_icon.line) {
+    bar_destroy_line(bar_manager->dnd_icon);
+  }
+
+  if (icon != bar_manager->_dnd_icon) {
+    if (bar_manager->_dnd_icon) {
+      free(bar_manager->_dnd_icon);
+    }
+
+    bar_manager->_dnd_icon = icon;
+  }
+
+  bar_manager->dnd_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_dnd_icon, rgba_color_from_hex(0xfffcf7bb));
+
+  bar_manager_refresh(bar_manager);
 }
 
 void bar_manager_display_changed(struct bar_manager *bar_manager)
@@ -195,6 +217,7 @@ void bar_manager_init(struct bar_manager *bar_manager)
     bar_manager_set_clock_format(bar_manager, string_copy("%R"));
     bar_manager_set_space_icon(bar_manager, string_copy("*"));
     bar_manager_set_power_strip(bar_manager, NULL);
+    bar_manager_set_dnd_icon(bar_manager, string_copy(""));
 }
 
 void bar_manager_begin(struct bar_manager *bar_manager)

--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -3,26 +3,28 @@
 
 struct bar_manager
 {
-    struct bar **bars;
-    int bar_count;
-    char *t_font_prop;
-    char *i_font_prop;
-    CTFontRef t_font;
-    CTFontRef i_font;
-    char **_space_icon_strip;
-    char **_power_icon_strip;
-    char *_clock_icon;
-    char *_clock_format;
-    char *_space_icon;
-    struct rgba_color foreground_color;
-    struct rgba_color background_color;
-    struct rgba_color space_icon_color;
-    struct rgba_color background_color_dim;
-    struct bar_line *space_icon_strip;
-    struct bar_line space_icon;
-    struct bar_line clock_icon;
-    struct bar_line battr_icon;
-    struct bar_line power_icon;
+  struct bar **bars;
+  int bar_count;
+  char *t_font_prop;
+  char *i_font_prop;
+  CTFontRef t_font;
+  CTFontRef i_font;
+  char **_space_icon_strip;
+  char **_power_icon_strip;
+  char *_clock_icon;
+  char *_clock_format;
+  char *_space_icon;
+  char *_dnd_icon;
+  struct rgba_color foreground_color;
+  struct rgba_color background_color;
+  struct rgba_color space_icon_color;
+  struct rgba_color background_color_dim;
+  struct bar_line *space_icon_strip;
+  struct bar_line space_icon;
+  struct bar_line clock_icon;
+  struct bar_line battr_icon;
+  struct bar_line power_icon;
+  struct bar_line dnd_icon;
 };
 
 void bar_manager_set_foreground_color(struct bar_manager *bar_manager, uint32_t color);
@@ -35,6 +37,7 @@ void bar_manager_set_power_strip(struct bar_manager *bar_manager, char **icon_st
 void bar_manager_set_clock_icon(struct bar_manager *bar_manager, char *icon);
 void bar_manager_set_clock_format(struct bar_manager *bar_manager, char *format);
 void bar_manager_set_space_icon(struct bar_manager *bar_manager, char *icon);
+void bar_manager_set_dnd_icon(struct bar_manager *bar_manager, char *icon);
 
 void bar_manager_display_changed(struct bar_manager *bar_manager);
 void bar_manager_refresh(struct bar_manager *bar_manager);

--- a/src/message.c
+++ b/src/message.c
@@ -22,6 +22,7 @@ extern bool g_verbose;
 #define COMMAND_CONFIG_BAR_SPACE_ICON        "space_icon"
 #define COMMAND_CONFIG_BAR_CLOCK_ICON        "clock_icon"
 #define COMMAND_CONFIG_BAR_CLOCK_FORMAT      "clock_format"
+#define COMMAND_CONFIG_BAR_DND_ICON          "dnd_icon"
 
 /* --------------------------------COMMON ARGUMENTS----------------------------- */
 #define ARGUMENT_COMMON_VAL_ON     "on"
@@ -208,9 +209,16 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
                 daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
             }
         }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_DND_ICON)) {
+      struct token token = get_token(&message);
+      if (!token_is_valid(token)) {
+	fprintf(rsp, "%s\n", g_bar_manager._dnd_icon ? g_bar_manager._dnd_icon : "");
+      } else {
+	bar_manager_set_dnd_icon(&g_bar_manager, token_to_string(token));
+      }
     }
     else {
-        daemon_fail(rsp, "unknown command '%.*s' for domain '%.*s'\n", command.length, command.text, domain.length, domain.text);
+      daemon_fail(rsp, "unknown command '%.*s' for domain '%.*s'\n", command.length, command.text, domain.length, domain.text);
     }
 }
 


### PR DESCRIPTION
Not sure if this is a feature others are interested in, but I chucked it together last night and figured others might like it.  
I can always implement a boolean switch to allow users to turn it off, if they prefer (or you can simply pass `""` as the `dnd_icon` value).

These changes introduce a DoNotDisturb indicator in the right strip, via a `dnd_icon` option.  

Colour is currently non-configurable - this will be added as an
enhancement in the future, along with colour options for other
elements in the right strip.

Here's what it looks like:
<img width="163" alt="image" src="https://user-images.githubusercontent.com/3392199/87065741-5b458b80-c209-11ea-9168-f6128da8d835.png">
