### PR TITLE
feature: Add options to change colours of right strip icons

### DIFF
--- a/doc/spacebar.1
+++ b/doc/spacebar.1
@@ -2,12 +2,12 @@
 .\"     Title: spacebar
 .\"    Author: [see the "AUTHOR(S)" section]
 .\" Generator: Asciidoctor 2.0.10
-.\"      Date: 2020-03-29
+.\"      Date: 2020-07-09
 .\"    Manual: Spacebar Manual
 .\"    Source: Spacebar
 .\"  Language: English
 .\"
-.TH "SPACEBAR" "1" "2020-03-29" "Spacebar" "Spacebar Manual"
+.TH "SPACEBAR" "1" "2020-07-09" "Spacebar" "Spacebar Manual"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -106,9 +106,24 @@ Specify two symbols separated by whitespace.
 The first symbol represents battery power and the second symbol indicates AC.
 .RE
 .sp
+\fBpower_icon_color\fP [\fI<COLOR>\fP]
+.RS 4
+Color to use for drawing the power (charing) icon.
+.RE
+.sp
+\fBbattery_icon_color\fP [\fI<COLOR>\fP]
+.RS 4
+Color to use for drawing the battery icon.
+.RE
+.sp
 \fBspace_icon\fP [\fI<sym>\fP]
 .RS 4
 Specify a general symbol to use for any given space that does not have a match in \fIspace_icon_strip\fP.
+.RE
+.sp
+\fBspace_icon_color\fP [\fI<COLOR>\fP]
+.RS 4
+Color to use for drawing the current space icon.
 .RE
 .sp
 \fBclock_icon\fP [\fI<sym>\fP]
@@ -116,9 +131,24 @@ Specify a general symbol to use for any given space that does not have a match i
 Specify a symbol to represent the current time.
 .RE
 .sp
+\fBclock_icon_color\fP [\fI<COLOR>\fP]
+.RS 4
+Color to use for drawing the clock icon.
+.RE
+.sp
 \fBclock_format\fP [\fI<sym>\fP]
 .RS 4
 Specify a format for the current time, according to the strftime function.
+.RE
+.sp
+\fBdnd_icon\fP [\fI<sym>\fP]
+.RS 4
+Specify a symbol to represent the current DoNotDisturb status.
+.RE
+.sp
+\fBdnd_icon_color\fP [\fI<COLOR>\fP]
+.RS 4
+Color to use for drawing the DoNotDisturb icon.
 .RE
 .SH "EXIT CODES"
 .sp

--- a/doc/spacebar.asciidoc
+++ b/doc/spacebar.asciidoc
@@ -81,17 +81,32 @@ Settings
     Specify two symbols separated by whitespace. +
     The first symbol represents battery power and the second symbol indicates AC.
 
+*power_icon_color* ['<COLOR>']::
+    Color to use for drawing the power (charing) icon.
+
+*battery_icon_color* ['<COLOR>']::
+    Color to use for drawing the battery icon.
+
 *space_icon* ['<sym>']::
     Specify a general symbol to use for any given space that does not have a match in 'space_icon_strip'.
 
+*space_icon_color* ['<COLOR>']::
+    Color to use for drawing the current space icon.
+
 *clock_icon* ['<sym>']::
     Specify a symbol to represent the current time.
+
+*clock_icon_color* ['<COLOR>']::
+    Color to use for drawing the clock icon.
 
 *clock_format* ['<sym>']::
     Specify a format for the current time, according to the strftime function.
 
 *dnd_icon* ['<sym>']::
     Specify a symbol to represent the current DoNotDisturb status.
+
+*dnd_icon_color* ['<COLOR>']::
+    Color to use for drawing the DoNotDisturb icon.
 
 Exit Codes
 ----------

--- a/examples/spacebarrc
+++ b/examples/spacebarrc
@@ -1,15 +1,19 @@
 #!/usr/bin/env sh
 
-spacebar -m config text_font         "Helvetica Neue:Bold:12.0"
-spacebar -m config icon_font         "Font Awesome 5 Free:Regular:12.0"
-spacebar -m config background_color  0xff202020
-spacebar -m config foreground_color  0xffa8a8a8
-spacebar -m config space_icon_color  0xff458588
-spacebar -m config space_icon_strip  I II III IV V VI VII VIII IX X
-spacebar -m config power_icon_strip   
-spacebar -m config space_icon        
-spacebar -m config clock_icon        
-spacebar -m config dnd_icon          
-spacebar -m config clock_format      "%d/%m/%y %R"
+spacebar -m config text_font          "Helvetica Neue:Bold:12.0"
+spacebar -m config icon_font          "Font Awesome 5 Free:Regular:12.0"
+spacebar -m config background_color   0xff202020
+spacebar -m config foreground_color   0xffa8a8a8
+spacebar -m config space_icon_color   0xff458588
+spacebar -m config power_icon_color   0xffcd950c
+spacebar -m config battery_icon_color 0xffd75f5f
+spacebar -m config dnd_icon_color     0xffa8a8a8
+spacebar -m config clock_icon_color   0xffa8a8a8
+spacebar -m config space_icon_strip   I II III IV V VI VII VIII IX X
+spacebar -m config power_icon_strip    
+spacebar -m config space_icon         
+spacebar -m config clock_icon         
+spacebar -m config dnd_icon           
+spacebar -m config clock_format       "%d/%m/%y %R"
 
 echo "spacebar configuration loaded.."

--- a/src/bar.c
+++ b/src/bar.c
@@ -271,11 +271,13 @@ void bar_refresh(struct bar *bar)
       CGPoint t_pos = bar_align_line(bar, time_line, ALIGN_RIGHT, ALIGN_CENTER);
       bar_draw_line(bar, time_line, t_pos.x, t_pos.y);
 
+      struct bar_line time_icon = g_bar_manager.clock_icon;
+      time_icon.color = g_bar_manager.clock_icon_color;
       CGPoint ti_pos = bar_align_line(bar, g_bar_manager.clock_icon, 0, ALIGN_CENTER);
       ti_pos.x = t_pos.x - g_bar_manager.clock_icon.bounds.size.width - 5;
       time_line_pos = ti_pos.x;
 
-      bar_draw_line(bar, g_bar_manager.clock_icon, ti_pos.x, ti_pos.y);
+      bar_draw_line(bar, time_icon, ti_pos.x, ti_pos.y);
       bar_destroy_line(time_line);
     }
 
@@ -292,6 +294,7 @@ void bar_refresh(struct bar *bar)
       bar_draw_line(bar, batt_line, p_pos.x, p_pos.y);
 
       struct bar_line batt_icon = charging ? g_bar_manager.power_icon : g_bar_manager.battr_icon;
+      batt_icon.color = charging ? g_bar_manager.power_icon_color : g_bar_manager.battery_icon_color;
       CGPoint pi_pos = bar_align_line(bar, batt_icon, 0, ALIGN_CENTER);
       pi_pos.x = p_pos.x - batt_icon.bounds.size.width;
       batt_line_pos = pi_pos.x;
@@ -304,6 +307,7 @@ void bar_refresh(struct bar *bar)
     bool dnd = [defaults boolForKey:@"doNotDisturb"];
     if (dnd) {
       struct bar_line dnd_icon = g_bar_manager.dnd_icon;
+      dnd_icon.color = g_bar_manager.dnd_icon_color;
       CGPoint di_pos = bar_align_line(bar, dnd_icon, 0, ALIGN_CENTER);
       di_pos.x = batt_line_pos - dnd_icon.bounds.size.width - 15;
 

--- a/src/bar_manager.c
+++ b/src/bar_manager.c
@@ -23,6 +23,30 @@ void bar_manager_set_space_icon_color(struct bar_manager *bar_manager, uint32_t 
   bar_manager_refresh(bar_manager);
 }
 
+void bar_manager_set_battery_icon_color(struct bar_manager *bar_manager, uint32_t color)
+{
+  bar_manager->battery_icon_color = rgba_color_from_hex(color);
+  bar_manager_refresh(bar_manager);
+}
+
+void bar_manager_set_power_icon_color(struct bar_manager *bar_manager, uint32_t color)
+{
+  bar_manager->power_icon_color = rgba_color_from_hex(color);
+  bar_manager_refresh(bar_manager);
+}
+
+void bar_manager_set_clock_icon_color(struct bar_manager *bar_manager, uint32_t color)
+{
+  bar_manager->clock_icon_color = rgba_color_from_hex(color);
+  bar_manager_refresh(bar_manager);
+}
+
+void bar_manager_set_dnd_icon_color(struct bar_manager *bar_manager, uint32_t color)
+{
+  bar_manager->dnd_icon_color = rgba_color_from_hex(color);
+  bar_manager_refresh(bar_manager);
+}
+
 void bar_manager_set_text_font(struct bar_manager *bar_manager, char *font_string)
 {
     if (bar_manager->t_font) {
@@ -110,14 +134,14 @@ void bar_manager_set_power_strip(struct bar_manager *bar_manager, char **icon_st
     }
 
     if (buf_len(bar_manager->_power_icon_strip) == 2) {
-        bar_manager->battr_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_power_icon_strip[0], rgba_color_from_hex(0xffd75f5f));
-        bar_manager->power_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_power_icon_strip[1], rgba_color_from_hex(0xffcd950c));
+      bar_manager->battr_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_power_icon_strip[0], bar_manager->battery_icon_color);
+      bar_manager->power_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_power_icon_strip[1], bar_manager->power_icon_color);
     } else {
-        bar_manager->battr_icon = bar_prepare_line(bar_manager->i_font, "", rgba_color_from_hex(0xffd75f5f));
-        bar_manager->power_icon = bar_prepare_line(bar_manager->i_font, "", rgba_color_from_hex(0xffcd950c));
+      bar_manager->battr_icon = bar_prepare_line(bar_manager->i_font, "", bar_manager->battery_icon_color);
+      bar_manager->power_icon = bar_prepare_line(bar_manager->i_font, "", bar_manager->power_icon_color);
     }
 
-    bar_manager_refresh(bar_manager);
+bar_manager_refresh(bar_manager);
 }
 
 void bar_manager_set_clock_icon(struct bar_manager *bar_manager, char *icon)
@@ -179,7 +203,7 @@ void bar_manager_set_dnd_icon(struct bar_manager *bar_manager, char *icon)
     bar_manager->_dnd_icon = icon;
   }
 
-  bar_manager->dnd_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_dnd_icon, rgba_color_from_hex(0xfffcf7bb));
+  bar_manager->dnd_icon = bar_prepare_line(bar_manager->i_font, bar_manager->_dnd_icon, bar_manager->dnd_icon_color);
 
   bar_manager_refresh(bar_manager);
 }
@@ -213,11 +237,15 @@ void bar_manager_init(struct bar_manager *bar_manager)
     bar_manager_set_background_color(bar_manager, 0xff202020);
     bar_manager_set_foreground_color(bar_manager, 0xffa8a8a8);
     bar_manager_set_space_icon_color(bar_manager, 0xffd75f5f);
+    bar_manager_set_battery_icon_color(bar_manager, 0xffd75f5f);
+    bar_manager_set_power_icon_color(bar_manager, 0xffcd950c);
+    bar_manager_set_clock_icon_color(bar_manager, 0xffa8a8a8);
     bar_manager_set_clock_icon(bar_manager, string_copy(" "));
     bar_manager_set_clock_format(bar_manager, string_copy("%R"));
     bar_manager_set_space_icon(bar_manager, string_copy("*"));
     bar_manager_set_power_strip(bar_manager, NULL);
     bar_manager_set_dnd_icon(bar_manager, string_copy(""));
+    bar_manager_set_dnd_icon_color(bar_manager, 0xffa8a8a8);
 }
 
 void bar_manager_begin(struct bar_manager *bar_manager)

--- a/src/bar_manager.h
+++ b/src/bar_manager.h
@@ -18,6 +18,10 @@ struct bar_manager
   struct rgba_color foreground_color;
   struct rgba_color background_color;
   struct rgba_color space_icon_color;
+  struct rgba_color battery_icon_color;
+  struct rgba_color power_icon_color;
+  struct rgba_color clock_icon_color;
+  struct rgba_color dnd_icon_color;
   struct rgba_color background_color_dim;
   struct bar_line *space_icon_strip;
   struct bar_line space_icon;
@@ -30,6 +34,10 @@ struct bar_manager
 void bar_manager_set_foreground_color(struct bar_manager *bar_manager, uint32_t color);
 void bar_manager_set_background_color(struct bar_manager *bar_manager, uint32_t color);
 void bar_manager_set_space_icon_color(struct bar_manager *bar_manager, uint32_t color);
+void bar_manager_set_battery_icon_color(struct bar_manager *bar_manager, uint32_t color);
+void bar_manager_set_power_icon_color(struct bar_manager *bar_manager, uint32_t color);
+void bar_manager_set_clock_icon_color(struct bar_manager *bar_manager, uint32_t color);
+void bar_manager_set_dnd_icon_color(struct bar_manager *bar_manager, uint32_t color);
 void bar_manager_set_text_font(struct bar_manager *bar_manager, char *font_string);
 void bar_manager_set_icon_font(struct bar_manager *bar_manager, char *font_string);
 void bar_manager_set_space_strip(struct bar_manager *bar_manager, char **icon_strip);

--- a/src/message.c
+++ b/src/message.c
@@ -11,18 +11,22 @@ extern bool g_verbose;
 #define DOMAIN_CONFIG  "config"
 
 /* --------------------------------DOMAIN CONFIG-------------------------------- */
-#define COMMAND_CONFIG_DEBUG_OUTPUT          "debug_output"
-#define COMMAND_CONFIG_BAR_TEXT_FONT         "text_font"
-#define COMMAND_CONFIG_BAR_ICON_FONT         "icon_font"
-#define COMMAND_CONFIG_BAR_SPACE_ICON_COLOR  "space_icon_color"
-#define COMMAND_CONFIG_BAR_BACKGROUND        "background_color"
-#define COMMAND_CONFIG_BAR_FOREGROUND        "foreground_color"
-#define COMMAND_CONFIG_BAR_SPACE_STRIP       "space_icon_strip"
-#define COMMAND_CONFIG_BAR_POWER_STRIP       "power_icon_strip"
-#define COMMAND_CONFIG_BAR_SPACE_ICON        "space_icon"
-#define COMMAND_CONFIG_BAR_CLOCK_ICON        "clock_icon"
-#define COMMAND_CONFIG_BAR_CLOCK_FORMAT      "clock_format"
-#define COMMAND_CONFIG_BAR_DND_ICON          "dnd_icon"
+#define COMMAND_CONFIG_DEBUG_OUTPUT            "debug_output"
+#define COMMAND_CONFIG_BAR_TEXT_FONT           "text_font"
+#define COMMAND_CONFIG_BAR_ICON_FONT           "icon_font"
+#define COMMAND_CONFIG_BAR_SPACE_ICON_COLOR    "space_icon_color"
+#define COMMAND_CONFIG_BAR_BATTERY_ICON_COLOR  "battery_icon_color"
+#define COMMAND_CONFIG_BAR_POWER_ICON_COLOR    "power_icon_color"
+#define COMMAND_CONFIG_BAR_CLOCK_ICON_COLOR    "clock_icon_color"
+#define COMMAND_CONFIG_BAR_DND_ICON_COLOR      "dnd_icon_color"
+#define COMMAND_CONFIG_BAR_BACKGROUND          "background_color"
+#define COMMAND_CONFIG_BAR_FOREGROUND          "foreground_color"
+#define COMMAND_CONFIG_BAR_SPACE_STRIP         "space_icon_strip"
+#define COMMAND_CONFIG_BAR_POWER_STRIP         "power_icon_strip"
+#define COMMAND_CONFIG_BAR_SPACE_ICON          "space_icon"
+#define COMMAND_CONFIG_BAR_CLOCK_ICON          "clock_icon"
+#define COMMAND_CONFIG_BAR_CLOCK_FORMAT        "clock_format"
+#define COMMAND_CONFIG_BAR_DND_ICON            "dnd_icon"
 
 /* --------------------------------COMMON ARGUMENTS----------------------------- */
 #define ARGUMENT_COMMON_VAL_ON     "on"
@@ -209,6 +213,54 @@ static void handle_domain_config(FILE *rsp, struct token domain, char *message)
                 daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
             }
         }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_BATTERY_ICON_COLOR)) {
+      struct token value = get_token(&message);
+      if (!token_is_valid(value)) {
+	fprintf(rsp, "0x%x\n", g_bar_manager.battery_icon_color.p);
+      } else {
+	uint32_t color = token_to_uint32t(value);
+	if (color) {
+	  bar_manager_set_battery_icon_color(&g_bar_manager, color);
+	} else {
+	  daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+	}
+      }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_POWER_ICON_COLOR)) {
+      struct token value = get_token(&message);
+      if (!token_is_valid(value)) {
+	fprintf(rsp, "0x%x\n", g_bar_manager.power_icon_color.p);
+      } else {
+	uint32_t color = token_to_uint32t(value);
+	if (color) {
+	  bar_manager_set_power_icon_color(&g_bar_manager, color);
+	} else {
+	  daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+	}
+      }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_CLOCK_ICON_COLOR)) {
+      struct token value = get_token(&message);
+      if (!token_is_valid(value)) {
+	fprintf(rsp, "0x%x\n", g_bar_manager.clock_icon_color.p);
+      } else {
+	uint32_t color = token_to_uint32t(value);
+	if (color) {
+	  bar_manager_set_clock_icon_color(&g_bar_manager, color);
+	} else {
+	  daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+	}
+      }
+    } else if (token_equals(command, COMMAND_CONFIG_BAR_DND_ICON_COLOR)) {
+      struct token value = get_token(&message);
+      if (!token_is_valid(value)) {
+	fprintf(rsp, "0x%x\n", g_bar_manager.dnd_icon_color.p);
+      } else {
+	uint32_t color = token_to_uint32t(value);
+	if (color) {
+	  bar_manager_set_dnd_icon_color(&g_bar_manager, color);
+	} else {
+	  daemon_fail(rsp, "unknown value '%.*s' given to command '%.*s' for domain '%.*s'\n", value.length, value.text, command.length, command.text, domain.length, domain.text);
+	}
+      }
     } else if (token_equals(command, COMMAND_CONFIG_BAR_DND_ICON)) {
       struct token token = get_token(&message);
       if (!token_is_valid(token)) {


### PR DESCRIPTION
These changes introduce the following options (should be pretty self
explanatory):
- power_icon_color
- battery_icon_color
- clock_icon_color
- dnd_icon_color

I've also taken the liberty of updating the docs